### PR TITLE
Cast quote total as string with expected decimal precision

### DIFF
--- a/app/code/community/Groove/Hubshoply/Model/Abandonedcart.php
+++ b/app/code/community/Groove/Hubshoply/Model/Abandonedcart.php
@@ -104,7 +104,7 @@ class Groove_Hubshoply_Model_Abandonedcart
             'email'      => $cart->getCustomerEmail(),
             'created_at' => date(DateTime::W3C,strtotime($cart->getCreatedAt())),
             'updated_at' => date(DateTime::W3C,strtotime($cart->getUpdatedAt())),
-            'total_price' => $cart->getGrandTotal(),
+            'total_price' => (string) number_format($cart->getGrandTotal(), 4),
             'product_ids' => $product_ids,
             'qty_in_cart' => $cart->getItemsQty(),
             'currency' => $cart->getQuoteCurrencyCode()


### PR DESCRIPTION
For some Magento shops, the quote grand total is not always in the expected format (string decimal to 4-point precision). In some cases, it is getting converted to a whole number when floating point values are "0." This is likely caused by an auxiliary observer on another extension in the Magento system -- probably an observer listening on quote post-load events. Whatever the cause, this fix addresses the issue by casting this quote grand total as a string every time it goes into the queue.